### PR TITLE
feat: OpenRouter balance check and list models utils added

### DIFF
--- a/llamea/utils.py
+++ b/llamea/utils.py
@@ -280,6 +280,17 @@ def clean_local_namespace(
 
 
 def check_credits() -> None:
+    """Retrieves and displays the credit limit and remaining balance for the current API key.
+
+    This function queries the OpenRouter API key endpoint to check the specific
+    financial limits associated with the provided credentials.
+
+    Args:
+        None. The function retrieves the API key from the environment variables.
+
+    Returns:
+        None. Prints the formatted credit balance (Remaining / Total) in USD to the console.
+    """
 
     api_key = os.getenv("OPENROUTER_API_KEY")
     if not api_key:


### PR DESCRIPTION
### Overview

This PR introduces two core utility functions to the `llamea/utils` module designed to simplify OpenRouter resource management and model discovery. It provides a CLI-ready interface for monitoring API credits and identifying cost-effective models via keyword filtering.

### Usage:
*(assuming the API key for OpenRouter was set with `export OPENROUTER_API_KEY="your_api_key_here"`)*
```bash
# General usage (list all)
uv run llamea/utils.py

# Filter for specific providers or architectures
uv run llamea/utils.py "google"
uv run llamea/utils.py "claude-3"
```